### PR TITLE
Build for 4.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4042125e7243e03465200bee787e55a54c16c1a10908718af75275c46bfafaad
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Currently version 4.2.2 is not in [conda](https://anaconda.org/conda-forge/fpocket/files). It may be because the build number was not reset at [#31](https://github.com/conda-forge/fpocket-feedstock/pull/31).
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
